### PR TITLE
parallel validator key generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/wealdtech/go-eth2-util v1.7.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Hey @protolambda . Nice tool! I'm using it to generate the genesis.ssz file for some private testnets on the fly. I was using it with 100k+ validators and it was taking me like 10min just to get the files generated. This change  makes spawning my networks from scratch quite faster :) 


### Parallelize the validator creation. 

```sh
$ time ./eth2-testnet-genesis phase0 --config config.yaml --mnemonics mnemonics.yaml --timestamp 1623884847 --tranches-dir tranches_new --state-output genesis_new.ssz
# 210.45s user 1.42s system 723% cpu 29.301 total

$ time ./eth2-testnet-genesis-old phase0 --config config.yaml --mnemonics mnemonics.yaml --timestamp 1623884847 --tranches-dir tranches_old --state-output genesis_old.ssz
# 121.11s user 3.50s system 120% cpu 1:43.09 total
```

Time sample from my local dev machine:
20.000 validators from 1 mnemonic was taking **1min43sec**. With the change it's taking me **29sec**

A quick sanity check:

```sh
# Comparing outputs to make sure we didn't break anything
$ diff tranches_new/tranche_0000.txt tranches_old/tranche_0000.txt # returns nothing, so we're good

$ zcli pretty phase0 BeaconState genesis_old.ssz > genesis_old.json
$ zcli pretty phase0 BeaconState genesis_new.ssz > genesis_new.json
$ diff genesis_old.json genesis_new.json # returns nothing, so we're good.
```
