### PR TITLE
Fix error generating genesis

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -42,6 +42,7 @@ func loadValidatorKeys(spec *common.Spec, mnemonicsConfigPath string, tranchesDi
 		for i := uint64(0); i < mnemonicSrc.Count; i++ {
 			mIdx := m
 			idx := i
+			index := (mnemonicSrc.Count * uint64(mIdx)) + idx
 			g.Go(func() error {
 				signingKey, err := util.PrivateKeyFromSeedAndPath(seed, validatorKeyName(idx))
 				if err != nil {
@@ -65,7 +66,7 @@ func loadValidatorKeys(spec *common.Spec, mnemonicsConfigPath string, tranchesDi
 
 				// Max effective balance by default for activation
 				data.Balance = spec.MAX_EFFECTIVE_BALANCE
-				validators[idx*uint64(mIdx+1)] = data
+				validators[index] = data
 				atomic.AddInt32(&prog, 1)
 				if prog%100 == 0 {
 					fmt.Printf("...validator %d/%d\n", prog, mnemonicSrc.Count)


### PR DESCRIPTION
There was a bug with validator index calculation resulting in overwrite of public keys when mnemonics are greater than 2

File: validators.go
Line: 68
Value: .............validators[idx*uint64(mIdx+1)] = data

Fixed and added dockerfile to create image