### PR TITLE
add a version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+GIT_COMMIT=$(shell git rev-list -1 HEAD)
+GIT_BRANCH=$(shell git branch --show-current)
+LDFLAGS=-X main.GitCommit=${GIT_COMMIT} -X main.GitBranch=${GIT_BRANCH}
+
+build:
+	go build -ldflags "${LDFLAGS}" ./...
+
+install:
+	go install -ldflags "${LDFLAGS}" ./...

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ func (c *GenesisCmd) Cmd(route string) (cmd interface{}, err error) {
 		cmd = &AltairGenesisCmd{}
 	case "merge":
 		cmd = &MergeGenesisCmd{}
+	case "version":
+		cmd = &VersionCmd{}
 	default:
 		return nil, fmt.Errorf("unrecognized cmd route: %s", route)
 	}
@@ -34,7 +36,7 @@ func (c *GenesisCmd) Cmd(route string) (cmd interface{}, err error) {
 }
 
 func (c *GenesisCmd) Routes() []string {
-	return []string{"phase0", "altair", "merge"}
+	return []string{"phase0", "altair", "merge", "version"}
 }
 
 func main() {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/protolambda/zrnt/eth2"
+)
+
+var GitCommit, GitBranch string
+
+type VersionCmd struct {
+}
+
+func (g *VersionCmd) Help() string {
+	return "Print version and exit"
+}
+
+func (g *VersionCmd) Default() {}
+
+func (g *VersionCmd) Run(ctx context.Context, args ...string) error {
+	fmt.Printf("version %s-%s-%s\n", eth2.VERSION, GitBranch, GitCommit[:6])
+	return nil
+}

--- a/version.go
+++ b/version.go
@@ -18,6 +18,14 @@ func (g *VersionCmd) Help() string {
 func (g *VersionCmd) Default() {}
 
 func (g *VersionCmd) Run(ctx context.Context, args ...string) error {
-	fmt.Printf("version %s-%s-%s\n", eth2.VERSION, GitBranch, GitCommit[:6])
+	var versionstr string
+	versionstr = eth2.VERSION
+	if len(GitBranch) > 0 {
+		versionstr += "-" + GitBranch
+	}
+	if len(GitCommit) > 6 {
+		versionstr += "-" + GitCommit[:6]
+	}
+	fmt.Printf("%s\n", versionstr)
 	return nil
 }


### PR DESCRIPTION
While debugging the verkle testnet with @parithosh, we found out that some time could have been saved if there had been a `version` command for this tool.

This PR adds it. It relies on the user to have the discipline to call `make`, not great, but better than nothing imo.