### PR TITLE
Fixing extradata size false failure with goerli

### DIFF
--- a/bellatrix.go
+++ b/bellatrix.go
@@ -129,7 +129,7 @@ func (g *BellatrixGenesisCmd) Run(ctx context.Context, args ...string) error {
 	eth1BlockHash = common.Root(eth1Block.Hash())
 
 	extra := eth1Block.Extra()
-	if len(extra) > common.MAX_EXTRA_DATA_BYTES {
+	if len(extra) > common.MAX_EXTRA_DATA_BYTES && eth1Genesis.Config.ChainID != big.NewInt(5) {
 		return fmt.Errorf("extra data is %d bytes, max is %d", len(extra), common.MAX_EXTRA_DATA_BYTES)
 	}
 

--- a/capella.go
+++ b/capella.go
@@ -129,7 +129,7 @@ func (g *CapellaGenesisCmd) Run(ctx context.Context, args ...string) error {
 	eth1BlockHash = common.Root(eth1Block.Hash())
 
 	extra := eth1Block.Extra()
-	if len(extra) > common.MAX_EXTRA_DATA_BYTES {
+	if len(extra) > common.MAX_EXTRA_DATA_BYTES && eth1Genesis.Config.ChainID != big.NewInt(5) {
 		return fmt.Errorf("extra data is %d bytes, max is %d", len(extra), common.MAX_EXTRA_DATA_BYTES)
 	}
 


### PR DESCRIPTION
the extradata field in goerli is bigger than the `MAX_EXTRA_DATA_BYTES`, so this PR adds an exception for goerli 